### PR TITLE
docs: Use new URL for github documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Click `Link` in the menu to link your GitHub account to the Slack workspace. Onl
 
 You can click `Setup GitHub projects` in the menu to get a webhook for connecting your GitHub projects.
 
-- [How to use GitHub webhook?](https://developer.github.com/webhooks/creating/)
+- [How to use GitHub webhook?](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/creating-webhooks)
 - The events sent to it should at least include `Pull requests` and `Pull request reviews`. Or `Send me everything` for easier setup.
 - The URL is bound to the workspace. And multiple projects can share one URL in one Slack workspace.
 


### PR DESCRIPTION
Github moved all documentation into a single place so the URL you point to is showing the message
`The content on this site may be out of date. For the most accurate and up-to-date content, visit https://docs.github.com/webhooks/creating/.`
When clicking no the link it redirects to the URL I updated in this commit.